### PR TITLE
Fix styling of product card components

### DIFF
--- a/pages/products.tsx
+++ b/pages/products.tsx
@@ -27,15 +27,15 @@ export default function Products({ products }: Props) {
   return (
     <div className="max-w-7xl mx-auto">
       <Header />
-      <div className="p-5 grid md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-5">
+      <div className="p-5 grid md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-5 justify-center sm:justify-left">
         {products.map((prod, i) => (
           <div
             key={i}
-            className="group max-w-sm bg-white hover:shadow-md overflow-hidden flex flex-col justify-between"
+            className="group lg:max-w-sm bg-white hover:shadow-md overflow-hidden flex flex-col justify-between"
           >
             <img
               key={i}
-              className="group-hover:scale-105 transition duration-200 ease-in-out"
+              className="group-hover:scale-105 transition duration-200 ease-in-out min-h-[56%]"
               src={urlFor(prod.images[0]).url()}
               alt=""
             />

--- a/pages/products.tsx
+++ b/pages/products.tsx
@@ -35,7 +35,7 @@ export default function Products({ products }: Props) {
           >
             <img
               key={i}
-              className="group-hover:scale-105 transition duration-200 ease-in-out min-h-[56%]"
+              className="group-hover:scale-105 transition duration-200 ease-in-out min-h-[53%]"
               src={urlFor(prod.images[0]).url()}
               alt=""
             />


### PR DESCRIPTION
# Overview

- This PR fixes the styling of product card components and also enables better responsiveness
- On larger screen sizes, certain images were taller than others and this made the card components look unaligned and strange
- On smaller viewports, the card components were fully left aligned, looking strange and also not ideal for mobile usage
- On medium sized viewports, there was unexpected spacing between card components

All these have been resolved in this PR 😄 

## Before

<img width="658" alt="Screen Shot 2022-09-30 at 10 37 57 PM" src="https://user-images.githubusercontent.com/28017034/193394459-9d28af2a-afec-4c5d-8377-5924c6328254.png">

<img width="569" alt="Screen Shot 2022-09-30 at 10 38 15 PM" src="https://user-images.githubusercontent.com/28017034/193394460-c57f85b7-aa19-40fd-b42b-3638255ceaba.png">

<img width="762" alt="Screen Shot 2022-09-30 at 10 38 38 PM" src="https://user-images.githubusercontent.com/28017034/193394461-7c7ef747-c3a9-4159-9a59-f90e269704ed.png">

## After

<img width="645" alt="Screen Shot 2022-09-30 at 10 43 28 PM" src="https://user-images.githubusercontent.com/28017034/193394611-33ce54f1-318e-4fb4-b9be-154e38d0fb7b.png">

<img width="393" alt="Screen Shot 2022-09-30 at 10 43 50 PM" src="https://user-images.githubusercontent.com/28017034/193394614-5ded3f0d-42ac-4059-a26c-a89fa5f2462f.png">

